### PR TITLE
Get path info from request

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -67,9 +67,9 @@ fn main() {
         }
     }
 
-    let url: &String = flags.iter().find_map(|flag| {
+    let url: &str = flags.iter().find_map(|flag| {
         match flag {
-            Flag::Url(flag) => Some(flag),
+            Flag::Url(flag) => Some(flag.as_str()),
             _ => None
         }
     }).unwrap_or_else(|| {
@@ -77,10 +77,10 @@ fn main() {
         process::exit(1);
     });
 
-    let headers: Vec<&String> = flags.iter().filter_map(|flag| {
+    let headers: Vec<&str> = flags.iter().filter_map(|flag| {
         match flag {
             Flag::Header(flag) => {
-                return Some(flag);
+                return Some(flag.as_str());
             },
             _ => None,
         }
@@ -96,54 +96,57 @@ fn main() {
     // TODO: if Flag is your own type, give it a fn as_method(&self) -> Option<&str> to shorten this
     // let method = flags.iter().find_map(|f| f.as_method()).unwrap_or("GET");
 
-    let (protocol, host, domain) = parse_url(url);
+    let (protocol, host, port, path) = parse_url(url);
+
+    let request_string = construct_get_request(protocol, host, port, path, method, headers);
 }
 
 pub fn is_valid_url(url: &str) -> bool {
     Url::parse(url).is_ok()
 }
 
-pub fn parse_url(url: &String) -> (String, String, String) {
-    let mut parts = url.splitn(2, "://");
-    let default_port = String::from("80");
+pub fn parse_url(url: &str) -> (&str, &str, &str, &str) {
+    let default_port = "80";
 
-    let protocol = match parts.next() {
-        Some(proto) => proto,
-        None => return ("".to_string(), "".to_string(), default_port)
-    };
-
-    let remaining = parts.next().unwrap_or("");
-
-    let (host, port) = if remaining.contains(":") {
-        let mut parts_of_host_port = remaining.splitn(2, ":");
-        let host = parts_of_host_port.next().unwrap();
-        let port = parts_of_host_port.next();
-        (host, port)
+    let (protocol, remaining_url) = if url.contains("://") {
+        let mut parts_of_protocol_url =  url.splitn(2, "://");
+        let protocol_part = parts_of_protocol_url.next().unwrap();
+        let remaining_url = parts_of_protocol_url.next().unwrap();
+        (protocol_part, remaining_url)
     } else {
-        (remaining, Some("80"))
+        ("", url)
     };
 
-    (protocol.to_string(), host.to_string(), port.unwrap().to_string())
+    let (host_and_port, path) = if remaining_url.contains("/") {
+        let mut parts_of_host_port_path = remaining_url.splitn(2, "/");
+        let host_and_port_part = parts_of_host_port_path.next().unwrap();
+        let path = parts_of_host_port_path.next().unwrap();
+        (host_and_port_part, path)
+    } else {
+        (remaining_url, "")
+    };
+
+    let (host, port) = if host_and_port.contains(":") {
+        let mut parts_of_host_port = host_and_port.splitn(2, ":");
+        let host_part = parts_of_host_port.next().unwrap();
+        let port = parts_of_host_port.next().unwrap();
+        (host_part, port)
+    } else {
+        (host_and_port, default_port)
+    };
+   
+
+    (protocol, host, port, path)
 }
 
-// pub fn construct_get_request(flags: Vec<Flag>) {
-//     let default_mothod = String::from("GET");
-//     let method = flags.iter().filter_map(|flag| match flag {
-//         Flag::Method(value) => Some(value),
-//         _ => None,
-//     });
-
-//     let headers = flags.iter().filter_map(|flag| match flag {
-//         Flag::Method(value) => Some(value),
-//         _ => None,
-//     }).collect::<Vec<&String>>();
-
-//     let mut res: String = String::from("");
+pub fn construct_get_request(protocol: &str, host: &str, port: &str, path: &str, method: &str, headers: Vec<&str>) {
+    let mut res: String = String::new();
     
-//     res += &format!("{} /{} {}\r\n", method, path, protocol);
-//     res += &format!("Host: {}\r\n", host);
-//     res += "Accept: */*\r\n";
-//     res += "Connection: close \r\n";
+    res += &format!("{} {}:{}/{} \r\n", method, host, port, path);
+    res += &format!("Protocol: {}\r\n", protocol);
+    res += &format!("Host: {}\r\n", host);
+    res += "Accept: */*\r\n";
+    res += "Connection: close \r\n";
 
-//     println!(res);
-// }
+    println!("{}", res);
+}


### PR DESCRIPTION
### Added
- Added the support to split the "path" from the request
- Also added the function which will help in getting the request info in raw string


### Fixed
- When protocol is not passed in request the `parse_url` was returning the whole url as `protocol` and the second part (which is supporsed to be url) as `empty string`  which is not expected. 
- Should return `protocol: ""` and `url:<URL>` 

_Can also add default protocol, probably "http"?_